### PR TITLE
58-Error-saving-viewable-of-type-torch_tensor-RuntimeError-result-type-Float-cant-be-cast-to-the-desired-output-type-Byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [3.0.12] - Patch
+
+### Added
+
+-   Convert to `float` when saving torch tensor.
+
 ## [3.0.9] - Pre-release
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "simply-view-image-for-python-debugging",
   "displayName": "View Image for Python Debugging",
   "description": "simply view the image of the image variables when debugging python",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "publisher": "elazarcoh",
   "icon": "icon.png",
   "preview": false,

--- a/src/python/torch_tensor.py
+++ b/src/python/torch_tensor.py
@@ -31,7 +31,7 @@ try:
 
             pad_value = 255
             torchvision.utils.save_image(
-                obj,
+                obj.float(),
                 path,
                 normalize=normalize,
                 pad_value=pad_value,


### PR DESCRIPTION
fixes #58