### PR TITLE
Feature request: Support "non-restricted types" in experimental viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.0.15] - Pre-release
+
+### Added
+- Support for "non-restricted types" in the viewer.
+  - If `svifpd.restrictImageTypes` is set to `false`, the viewer will now also support everything that is convertible to a numpy array (e.g., `tensorflow.Tensor` which is not supported by default).
+
 ## [4.0.13] - Pre-release
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ Monitor image, plot, or tensor variables and refresh the view at each breakpoint
 
 ## Settings
 
-| Setting                  | Description                                                                                                                                                                                                                                                                                    | Default Value |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `svifpd.autoFetchImages` | Controls whether images are automatically fetched. <ul> <li><code>true</code>: Automatically fetch images at each step.</li> <li><code>false</code>: Fetch images only when the "Fetch Image" button is clicked.</li> <li><code>"pinned"</code>: Automatically fetch pinned images.</li> </ul> | `true`        |
+| Setting                     | Description                                                                                                                                                                                                                                                                                    | Default Value |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `svifpd.autoFetchImages`    | Controls whether images are automatically fetched. <ul> <li><code>true</code>: Automatically fetch images at each step.</li> <li><code>false</code>: Fetch images only when the "Fetch Image" button is clicked.</li> <li><code>"pinned"</code>: Automatically fetch pinned images.</li> </ul> | `true`        |
+| `svifpd.restrictImageTypes` | Restricts the types that are considered images. <ul> <li><code>true</code>: Only numpy is checked.</li> <li><code>false</code>: All types are checked.</li> </ul> This setting is useful for improving performance in some cases.                                                              | `true`        |
 
 ## Q&A
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "simply-view-image-for-python-debugging",
   "displayName": "View Image for Python Debugging",
   "description": "simply view the image of the image variables when debugging python",
-  "version": "4.0.13",
+  "version": "4.0.15",
   "publisher": "elazarcoh",
   "icon": "icon.png",
   "preview": false,

--- a/src/python/numpy_tensor.py
+++ b/src/python/numpy_tensor.py
@@ -2,14 +2,20 @@ import numpy as np
 
 
 def numpy_tensor():
-    def is_numpy_tensor(obj):
+    def is_numpy_tensor(obj, restrict_types):
         try:
             import numpy as np
         except ImportError:
             return False
         valid_channels = (1, 3, 4)
+        is_valid = True
         try:
-            is_valid = isinstance(obj, np.ndarray)
+            if restrict_types:
+                try:
+                    is_valid = isinstance(obj, np.ndarray)
+                except TypeError:
+                    return False
+                
             is_valid &= len(obj.shape) in (3, 4)
             if len(obj.shape) == 3:
                 pass

--- a/src/viewable/Tensor.ts
+++ b/src/viewable/Tensor.ts
@@ -1,7 +1,10 @@
 import NUMPY_TENSOR_CODE from "../python/numpy_tensor.py?raw";
 import TORCH_TENSOR_CODE from "../python/torch_tensor.py?raw";
 import { Viewable } from "./Viewable";
-import { atModule as m } from "../python-communication/BuildPythonCode";
+import {
+  convertBoolToPython,
+  atModule as m,
+} from "../python-communication/BuildPythonCode";
 import { ArrayDataType } from "../common/datatype";
 import { getConfiguration } from "../config";
 
@@ -21,7 +24,8 @@ export const NumpyTensor: Viewable<NumpyTensorInfo> = {
     id: "numpy_tensor",
   },
   testTypePythonCode: {
-    evalCode: (expression: string) => `${m("is_numpy_tensor")}(${expression})`,
+    evalCode: (expression: string) =>
+      `${m("is_numpy_tensor")}(${expression}, restrict_types=${convertBoolToPython(getConfiguration("restrictImageTypes") ?? true)})`,
   },
   infoPythonCode: {
     evalCode: (expression: string) =>


### PR DESCRIPTION
fixes #99
When `restrictImageTypes` is set to `false`, the viewer will also display non-numpy/pillow/torch images