### PR TITLE
Release 4.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## [4.0.20] - Release - 2026-05-25
+
+### Added
+
+- Support for saving images directly from the webview
+- Setting to control auto-run setup on debug start (`svifpd.autoRunSetupOnDebugStart`) with toggle buttons in the Image Watch view
+- Setting to control whether images are automatically fetched (`svifpd.autoFetchImages`: `true` / `false` / `"pinned"`)
+- Support for "non-restricted types": when `svifpd.restrictImageTypes` is set to `false`, the viewer also supports everything convertible to a numpy array (e.g. `tensorflow.Tensor`)
+- Support for Interactive Python cells
+
+### Fixed
+
+- Fixed indexed-color PNG interpretation (now uses Jimp-expanded channels)
+- Fixed preprocessing for single-channel images in save functions
+- Fixed bug with numpy tensors not being sent correctly to the viewer
+- Fixed bug with font loading in the image viewer
+- Fixed bug with pinned images not being kept when switching debug sessions
+
+### Security
+
+- Bumped `lodash` to 4.18.1 (fixes GHSA-r5fr-rjxr-66jc high severity: code injection via `_.template`; GHSA-f23m-r3pf-42rh moderate severity: prototype pollution)
+- Replaced deprecated `vscode-debugprotocol` with its renamed successor `@vscode/debugprotocol`
+
 ## [4.0.19] - Pre-release
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
 
 - Bumped `lodash` to 4.18.1 (fixes GHSA-r5fr-rjxr-66jc high severity: code injection via `_.template`; GHSA-f23m-r3pf-42rh moderate severity: prototype pollution)
 - Replaced deprecated `vscode-debugprotocol` with its renamed successor `@vscode/debugprotocol`
+- Bumped transitive `ws` to 8.21.0 (fixes HIGH severity remote DoS via malformed headers)
+- Bumped transitive `postcss` to 8.5.15 (fixes XSS via unescaped `</style>` in source maps, introduced in 8.5.10)
+- Bumped transitive `basic-ftp` to 5.3.1 (fixes GHSA-rpmf-866q-6p89, GHSA-rp42-5vxx-qpwr, GHSA-6v7q-wjvx-w8wg, GHSA-chqc-8p9q-pq6q: path traversal and DoS)
+- Bumped transitive `brace-expansion` to 1.1.14 (fixes GHSA-7h2j-956f-4vf2, GHSA-f886-m6hf-6m8v)
+- Bumped transitive `fast-uri` to 3.1.2 (fixes GHSA-v39h-62p7-jpjc, GHSA-q3j6-qgpj-74h6)
+- Bumped transitive `qs` to 6.15.2 (bug fixes)
+- Bumped transitive `@tootallnate/once` to 2.0.1 (bug fix)
 
 ## [4.0.19] - Pre-release
 

--- a/package.json
+++ b/package.json
@@ -623,5 +623,15 @@
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4",
     "webpack-shell-plugin-next": "^2.3.2"
+  },
+  "resolutions": {
+    "@tootallnate/once": "2.0.1",
+    "basic-ftp": "5.3.1",
+    "brace-expansion": "1.1.14",
+    "fast-uri": "3.1.2",
+    "lodash": "4.18.1",
+    "postcss": "8.5.15",
+    "qs": "6.15.2",
+    "ws": "8.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "elazarcoh",
   "name": "simply-view-image-for-python-debugging",
   "displayName": "View Image for Python Debugging",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "packageManager": "yarn@4.4.1",
   "workspaces": [
     "icons"
@@ -571,15 +571,15 @@
   "dependencies": {
     "@jupyterlab/services": "^7.3.5",
     "@vscode/codicons": "^0.0.36",
+    "@vscode/debugprotocol": "^1.68.0",
     "@vscode/jupyter-extension": "^1.1.1",
     "exifreader": "^4.26.1",
     "jimp": "^1.6.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "parsimmon": "^1.18.1",
     "reflect-metadata": "^0.2.2",
     "ts-results": "^3.3.0",
     "typedi": "^0.10.0",
-    "vscode-debugprotocol": "^1.51.0",
     "vscode-extensions-json-generator": "^0.2.2"
   },
   "devDependencies": {

--- a/src/python-communication/RunPythonCode.ts
+++ b/src/python-communication/RunPythonCode.ts
@@ -1,5 +1,5 @@
 import type { Kernel } from '@vscode/jupyter-extension';
-import type { DebugProtocol } from 'vscode-debugprotocol';
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { Session } from '../session/Session';
 import type { Result } from '../utils/Result';
 import * as vscode from 'vscode';

--- a/src/python-communication/RunPythonCode.ts
+++ b/src/python-communication/RunPythonCode.ts
@@ -1,5 +1,5 @@
-import type { Kernel } from '@vscode/jupyter-extension';
 import type { DebugProtocol } from '@vscode/debugprotocol';
+import type { Kernel } from '@vscode/jupyter-extension';
 import type { Session } from '../session/Session';
 import type { Result } from '../utils/Result';
 import * as vscode from 'vscode';

--- a/src/session/debugger/DebugAdapterTracker.ts
+++ b/src/session/debugger/DebugAdapterTracker.ts
@@ -1,5 +1,5 @@
-import type * as vscode from 'vscode';
 import type { DebugProtocol } from '@vscode/debugprotocol';
+import type * as vscode from 'vscode';
 import _ from 'lodash';
 import { Option } from 'ts-results';
 import Container from 'typedi';

--- a/src/session/debugger/DebugAdapterTracker.ts
+++ b/src/session/debugger/DebugAdapterTracker.ts
@@ -1,5 +1,5 @@
 import type * as vscode from 'vscode';
-import type { DebugProtocol } from 'vscode-debugprotocol';
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import _ from 'lodash';
 import { Option } from 'ts-results';
 import Container from 'typedi';

--- a/src/session/debugger/DebugRelatedCommands.ts
+++ b/src/session/debugger/DebugRelatedCommands.ts
@@ -1,4 +1,4 @@
-import type { DebugProtocol } from 'vscode-debugprotocol';
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
 import { findExpressionViewables } from '../../PythonObjectInfo';
 import { debugSession } from '../../session/Session';

--- a/src/session/debugger/DebugVariablesTracker.ts
+++ b/src/session/debugger/DebugVariablesTracker.ts
@@ -1,4 +1,4 @@
-import type { DebugProtocol } from 'vscode-debugprotocol';
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import { logDebug } from '../../Logging';
 import { PYTHON_MODULE_NAME } from '../../python-communication/BuildPythonCode';
 

--- a/src/session/debugger/debug-protocol.d.ts
+++ b/src/session/debugger/debug-protocol.d.ts
@@ -1,4 +1,4 @@
-import type { DebugProtocol } from 'vscode-debugprotocol';
+import type { DebugProtocol } from '@vscode/debugprotocol';
 
 type DebugProtocolVariable = Required<
   Pick<DebugProtocol.Variable, 'name' | 'evaluateName' | 'type'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2638,10 +2638,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: 10c0/073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
+"@tootallnate/once@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@tootallnate/once@npm:2.0.1"
+  checksum: 10c0/23b01a341485be711c602077936d70f8e695405bb88ab4433dc6d1e6cb4556401518789574d399eded790b70b27738136c9a8f02df7ae4219f4ba28bb22d586b
   languageName: node
   linkType: hard
 
@@ -3993,13 +3993,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^4.0.2":
-  version: 4.0.4
-  resolution: "balanced-match@npm:4.0.4"
-  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
-  languageName: node
-  linkType: hard
-
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -4016,10 +4009,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.2.0
-  resolution: "basic-ftp@npm:5.2.0"
-  checksum: 10c0/a0f85c01deae0723021f9bf4a7be29378186fa8bba41e74ea11832fe74c187ce90c3599c3cc5ec936581cfd150020e79f4a9ed0ee9fb20b2308e69b045f3a059
+"basic-ftp@npm:5.3.1":
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10c0/03511b488cd292abfa82a8c0ea3b9573b40d12d2f1518d6f41a9461b012b3376d3e6d50679b38d9b2b4f48fd6e8e0418ac196312ee7e2da13cb801169940d1c3
   languageName: node
   linkType: hard
 
@@ -4125,31 +4118,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+"brace-expansion@npm:1.1.14":
+  version: 1.1.14
+  resolution: "brace-expansion@npm:1.1.14"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
+  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
   languageName: node
   linkType: hard
 
@@ -6811,10 +6786,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+"fast-uri@npm:3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 
@@ -9053,21 +9028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.5":
-  version: 4.17.5
-  resolution: "lodash@npm:4.17.5"
-  checksum: 10c0/f381afb66e38fe121f64b765128ef788d2752a105c22abdc86fc2756b3eaddf723812f2d8b0b1dddffee64ab163468ead5d11604310d6c1eb134d0b0648aa434
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.15.0, lodash@npm:^4.17.10, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.23, lodash@npm:^4.17.4":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.18.1":
+"lodash@npm:4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
@@ -10290,12 +10251,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.12":
+  version: 3.3.12
+  resolution: "nanoid@npm:3.3.12"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
   languageName: node
   linkType: hard
 
@@ -11360,14 +11321,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.6":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
+"postcss@npm:8.5.15":
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.12"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
+  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
   languageName: node
   linkType: hard
 
@@ -11553,12 +11514,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.9.1":
-  version: 6.15.0
-  resolution: "qs@npm:6.15.0"
+"qs@npm:6.15.2":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 
@@ -14633,9 +14594,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.19.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
+"ws@npm:8.21.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -14644,7 +14605,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,6 +3208,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vscode/debugprotocol@npm:^1.68.0":
+  version: 1.68.0
+  resolution: "@vscode/debugprotocol@npm:1.68.0"
+  checksum: 10c0/e4b21bad518f7db66f7bd5c07b8303af36dbee920c9250d0f5d3910fb181ee1f7e83c536004b3258041d54d18c86fc361de3c2225958a458dbf5ece99c317870
+  languageName: node
+  linkType: hard
+
 "@vscode/jupyter-extension@npm:^1.1.1":
   version: 1.1.1
   resolution: "@vscode/jupyter-extension@npm:1.1.1"
@@ -9060,6 +9067,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -12502,6 +12516,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.24.0"
     "@vitest/coverage-v8": "npm:^4.0.18"
     "@vscode/codicons": "npm:^0.0.36"
+    "@vscode/debugprotocol": "npm:^1.68.0"
     "@vscode/jupyter-extension": "npm:^1.1.1"
     "@vscode/vsce": "npm:^3.2.2"
     "@wasm-tool/wasm-pack-plugin": "patch:@wasm-tool/wasm-pack-plugin@npm%3A1.7.0#~/.yarn/patches/@wasm-tool-wasm-pack-plugin-npm-1.7.0-05c10ff10e.patch"
@@ -12516,7 +12531,7 @@ __metadata:
     husky: "npm:^9.1.7"
     jimp: "npm:^1.6.0"
     lethargy-ts: "npm:^0.1.0"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.18.1"
     lodash-cli: "npm:^4.17.5"
     mini-css-extract-plugin: "npm:^2.9.1"
     mocha: "npm:^11.7.1"
@@ -12533,7 +12548,6 @@ __metadata:
     typescript: "npm:^5.6.2"
     typescript-eslint: "npm:^8.24.0"
     vitest: "npm:^4.0.18"
-    vscode-debugprotocol: "npm:^1.51.0"
     vscode-extension-tester: "patch:vscode-extension-tester@npm%3A8.22.1#~/.yarn/patches/vscode-extension-tester-npm-8.22.1-1ba05efd5d.patch"
     vscode-extensions-json-generator: "npm:^0.2.2"
     wasm-pack: "npm:^0.13.1"
@@ -14179,13 +14193,6 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 10c0/b913cd32032c95f29ff08c931f4b4c6fd6d2da498908d6770952c561a1b8d75c62499a1f04cadf82fb89cc0f9a33f29fb5dfdb899f6dbb27686a9d91571be5fa
-  languageName: node
-  linkType: hard
-
-"vscode-debugprotocol@npm:^1.51.0":
-  version: 1.51.0
-  resolution: "vscode-debugprotocol@npm:1.51.0"
-  checksum: 10c0/ea51a575aabbbfa9d66bfca48e001435576ed1ec909f17a941aeee3ba7792dae1b27222eadd12a8504aaeab9811f462fcceaf9ae6df02b7e4d5ad9c7da54692e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Release 4.0.20

Promotes accumulated pre-release versions (4.0.11–4.0.19) to a stable release, with security dependency bumps.

---

### Changes included in this release

**Added**
- Support for saving images directly from the webview
- `svifpd.autoRunSetupOnDebugStart` setting + toggle buttons in the Image Watch view
- `svifpd.autoFetchImages` setting (`true` / `false` / `"pinned"`) to control automatic image fetching
- Support for "non-restricted types": when `svifpd.restrictImageTypes` is `false`, also supports everything convertible to a numpy array (e.g. `tensorflow.Tensor`)
- Support for Interactive Python cells

**Fixed**
- Indexed-color PNG interpretation (now uses Jimp-expanded channels)
- Preprocessing for single-channel images in save functions
- Numpy tensors not being sent correctly to the viewer
- Font loading in the image viewer
- Pinned images not being kept when switching debug sessions

**Security**
- Bumped `lodash` from 4.17.21 → 4.18.1
  - [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) **HIGH**: code injection via `_.template` (lodash usage here is only `_.throttle`/`_.debounce` — not directly exploitable, but advisory cleared)
  - [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) **moderate**: prototype pollution via `_.unset`/`_.omit`
- Replaced deprecated `vscode-debugprotocol@1.51.0` with its renamed successor `@vscode/debugprotocol@1.68.0` (5 import sites updated)

**Known remaining audit finding (not blocking)**
- `text-encoding@0.7.0` — moderate deprecation; used as a webpack `ProvidePlugin` polyfill for `TextEncoder`/`TextDecoder` in the webview build. Modern VS Code's Chromium runtime has these natively. Removal requires webview build testing and is tracked as a separate follow-up.

---

### Post-merge steps
After this PR merges to `main`:
1. Tag the merge commit: `git tag 4.0.20`
2. Push tag: `git push origin 4.0.20`
3. The [release workflow](../../actions/workflows/release.yml) auto-publishes to VS Marketplace and Open VSX Registry.