### PR TITLE
ci(dependabot): add grouped, monthly Dependabot config + auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,133 @@
+# Dependabot configuration
+#
+# Goal: a small, predictable number of grouped PRs (roughly 2-3 on the 1st of
+# each month), instead of one PR per dependency. Security updates are grouped
+# too, so an advisory burst arrives as a single PR per ecosystem.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+
+updates:
+  # ── npm / yarn 4 ────────────────────────────────────────────────────────────
+  # The root manifest also covers the `icons` workspace member (package.json
+  # `workspaces: ["icons"]`), so no separate entry is needed for it.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly # runs on the 1st of the month
+      time: "05:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore # -> "chore(deps):" / "chore(deps-dev):"
+      include: scope
+    labels: ["dependencies", "javascript"]
+    cooldown:
+      # Let releases settle before picking them up, so we don't chase
+      # same-week regressions.
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      npm-runtime:
+        # Ships inside the .vsix - the group that actually needs review.
+        applies-to: version-updates
+        dependency-type: production
+        update-types: [minor, patch]
+      npm-tooling:
+        # Build / lint / test only. Safe to merge on green CI.
+        applies-to: version-updates
+        dependency-type: development
+        update-types: [minor, patch]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+    ignore:
+      # These are consumed through yarn's `patch:` protocol
+      # (.yarn/patches/*.patch). A version bump silently invalidates the patch
+      # and breaks `yarn install --immutable`.
+      - dependency-name: "vscode-extension-tester"
+      - dependency-name: "@wasm-tool/wasm-pack-plugin"
+      # @types/vscode must stay <= engines.vscode (^1.63.0). Even a minor bump
+      # raises the minimum VS Code version the extension claims to support.
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      # Pinned deliberately.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
+  # ── GitHub Actions ──────────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: ci
+      include: scope
+    labels: ["dependencies", "github-actions"]
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # ── Rust / wasm webview ─────────────────────────────────────────────────────
+  # Patch-only on purpose: nearly every crate here is 0.x (yew 0.21, image 0.24,
+  # ndarray 0.15, strum 0.25, ...), where a "minor" bump is a breaking change,
+  # and there is no committed Cargo.lock to catch drift.
+  - package-ecosystem: cargo
+    directories:
+      - "/src/webview-ui"
+      - "/src/webview-ui/shaders"
+    schedule:
+      interval: quarterly
+      time: "05:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: chore
+      include: scope
+    labels: ["dependencies", "rust"]
+    cooldown:
+      default-days: 14
+    groups:
+      cargo-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: [patch]
+      cargo-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # ── example-plugin ──────────────────────────────────────────────────────────
+  # Demo code with its own yarn.lock and no CI. No version updates (limit 0),
+  # but keep security fixes flowing as a single grouped PR.
+  - package-ecosystem: npm
+    directory: "/example-plugin"
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: chore
+      include: scope
+    labels: ["dependencies", "example-plugin"]
+    groups:
+      example-plugin-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # NOTE: tests/unit/python/requirements.txt and
+  # tests/test-data/workspace/requirements.txt are intentionally NOT configured.
+  # They are unpinned (pytest / numpy / matplotlib / Pillow), so there are no
+  # version constraints for Dependabot to update.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,8 +74,9 @@ updates:
       include: scope
     labels: [dependencies, github-actions]
     cooldown:
+      # Only `default-days` is supported for the github-actions ecosystem;
+      # the semver-* variants are rejected at config-validation time.
       default-days: 7
-      semver-major-days: 30
     groups:
       github-actions:
         patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,19 +9,19 @@ version: 2
 
 updates:
   # ── npm / yarn 4 ────────────────────────────────────────────────────────────
-  # The root manifest also covers the `icons` workspace member (package.json
-  # `workspaces: ["icons"]`), so no separate entry is needed for it.
+  # The root manifest also covers the `icons` workspace member (the `workspaces`
+  # field in package.json), so no separate entry is needed for it.
   - package-ecosystem: npm
-    directory: "/"
+    directory: /
     schedule:
       interval: monthly # runs on the 1st of the month
-      time: "05:00"
-      timezone: "Etc/UTC"
+      time: '05:00'
+      timezone: Etc/UTC
     open-pull-requests-limit: 3
     commit-message:
-      prefix: chore # -> "chore(deps):" / "chore(deps-dev):"
+      prefix: chore # -> chore(deps): / chore(deps-dev):
       include: scope
-    labels: ["dependencies", "javascript"]
+    labels: [dependencies, javascript]
     cooldown:
       # Let releases settle before picking them up, so we don't chase
       # same-week regressions.
@@ -40,45 +40,45 @@ updates:
         update-types: [minor, patch]
       npm-security:
         applies-to: security-updates
-        patterns: ["*"]
+        patterns: ['*']
     ignore:
       # These are consumed through yarn's `patch:` protocol
       # (.yarn/patches/*.patch). A version bump silently invalidates the patch
       # and breaks `yarn install --immutable`.
-      - dependency-name: "vscode-extension-tester"
-      - dependency-name: "@wasm-tool/wasm-pack-plugin"
+      - dependency-name: vscode-extension-tester
+      - dependency-name: '@wasm-tool/wasm-pack-plugin'
       # @types/vscode must stay <= engines.vscode (^1.63.0). Even a minor bump
       # raises the minimum VS Code version the extension claims to support.
-      - dependency-name: "@types/vscode"
+      - dependency-name: '@types/vscode'
         update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
       # Pinned deliberately.
-      - dependency-name: "react"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: react
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
 
   # ── GitHub Actions ──────────────────────────────────────────────────────────
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: monthly
-      time: "05:00"
-      timezone: "Etc/UTC"
+      time: '05:00'
+      timezone: Etc/UTC
     open-pull-requests-limit: 1
     commit-message:
       prefix: ci
       include: scope
-    labels: ["dependencies", "github-actions"]
+    labels: [dependencies, github-actions]
     cooldown:
       default-days: 7
       semver-major-days: 30
     groups:
       github-actions:
-        patterns: ["*"]
+        patterns: ['*']
 
   # ── Rust / wasm webview ─────────────────────────────────────────────────────
   # Patch-only on purpose: nearly every crate here is 0.x (yew 0.21, image 0.24,
@@ -86,46 +86,46 @@ updates:
   # and there is no committed Cargo.lock to catch drift.
   - package-ecosystem: cargo
     directories:
-      - "/src/webview-ui"
-      - "/src/webview-ui/shaders"
+      - /src/webview-ui
+      - /src/webview-ui/shaders
     schedule:
       interval: quarterly
-      time: "05:00"
-      timezone: "Etc/UTC"
+      time: '05:00'
+      timezone: Etc/UTC
     open-pull-requests-limit: 1
     commit-message:
       prefix: chore
       include: scope
-    labels: ["dependencies", "rust"]
+    labels: [dependencies, rust]
     cooldown:
       default-days: 14
     groups:
       cargo-patch:
         applies-to: version-updates
-        patterns: ["*"]
+        patterns: ['*']
         update-types: [patch]
       cargo-security:
         applies-to: security-updates
-        patterns: ["*"]
+        patterns: ['*']
 
   # ── example-plugin ──────────────────────────────────────────────────────────
   # Demo code with its own yarn.lock and no CI. No version updates (limit 0),
   # but keep security fixes flowing as a single grouped PR.
   - package-ecosystem: npm
-    directory: "/example-plugin"
+    directory: /example-plugin
     schedule:
       interval: monthly
-      time: "05:00"
-      timezone: "Etc/UTC"
+      time: '05:00'
+      timezone: Etc/UTC
     open-pull-requests-limit: 0
     commit-message:
       prefix: chore
       include: scope
-    labels: ["dependencies", "example-plugin"]
+    labels: [dependencies, example-plugin]
     groups:
       example-plugin-security:
         applies-to: security-updates
-        patterns: ["*"]
+        patterns: ['*']
 
   # NOTE: tests/unit/python/requirements.txt and
   # tests/test-data/workspace/requirements.txt are intentionally NOT configured.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,55 @@
+# Enables GitHub's auto-merge on the low-risk Dependabot groups, so they land
+# on their own once "🚦 Status Check" (the required check on main) goes green.
+#
+# Everything else - the npm-runtime group, security groups, and any major bump -
+# is left for manual review.
+#
+# Prerequisites, all already satisfied on this repo:
+#   * Settings -> "Allow auto-merge" is enabled
+#   * `🚦 Status Check` is a required status check on `main`
+#   * Dependabot PRs receive a write GITHUB_TOKEN here (verified: the CI summary
+#     comment in test.yml posts successfully on Dependabot PRs)
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        # Dev-only tooling, CI actions, and anything that is patch-only.
+        # `update-type` on a grouped PR is the highest bump in the group, so a
+        # major sneaking into a group disqualifies the whole PR.
+        if: >-
+          steps.meta.outputs.dependency-group == 'npm-tooling' ||
+          steps.meta.outputs.dependency-group == 'github-actions' ||
+          steps.meta.outputs.dependency-group == 'cargo-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch'
+        # Merge commit is the only method enabled on this repo.
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          {
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| group | \`${{ steps.meta.outputs.dependency-group }}\` |"
+            echo "| update-type | \`${{ steps.meta.outputs.update-type }}\` |"
+            echo "| ecosystem | \`${{ steps.meta.outputs.package-ecosystem }}\` |"
+            echo "| dependencies | ${{ steps.meta.outputs.dependency-names }} |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

There was no `.github/dependabot.yml` in this repo, so every Dependabot PR was an **alert-driven security update**: one PR per advisory, ungrouped, each one running the full ~16 min UI suite. There were also **no version updates at all** — direct dependencies only moved when an advisory forced them.

Result: 8 open PRs, one per package, and CI burned on each.

## What this changes

A config that groups updates and puts them on a predictable monthly cadence. Expected steady state is **2–3 PRs on the 1st of the month**, plus at most one grouped security PR per ecosystem when an advisory lands.

| Ecosystem | Where | Cadence | Groups |
|---|---|---|---|
| npm (yarn 4) | `/` — also covers the `icons` workspace member | monthly | `npm-runtime` (prod), `npm-tooling` (dev), `npm-security` |
| github-actions | `.github/workflows` | monthly | one group |
| cargo | `src/webview-ui`, `src/webview-ui/shaders` | quarterly | `cargo-patch` (patch only), `cargo-security` |
| example-plugin | `/example-plugin` | — | version updates off (`limit: 0`), grouped security only |

**pip is deliberately not configured.** Both `requirements.txt` files are unpinned (`pytest`, `numpy`, `matplotlib`, `Pillow`), so there are no version constraints for Dependabot to update.

**Cargo is patch-only on purpose.** Nearly every crate in the webview is 0.x (`yew 0.21`, `image 0.24`, `ndarray 0.15`, `strum 0.25`, ...), where a "minor" bump is a breaking change — and there is no committed `Cargo.lock` to catch drift.

## Ignore rules

These are the bumps that would break the build:

- **`vscode-extension-tester`** and **`@wasm-tool/wasm-pack-plugin`** are consumed through yarn's `patch:` protocol. A version bump silently invalidates `.yarn/patches/*.patch` and breaks `yarn install --immutable`.
- **`@types/vscode`** is capped at minor. Raising it raises the minimum VS Code API version the extension claims to support, which must stay `<= engines.vscode` (`^1.63.0`).
- **`react` / `@types/react` / `@types/node`** majors stay pinned.

## Auto-merge workflow

Enables GitHub auto-merge on the low-risk groups only — `npm-tooling`, `github-actions`, `cargo-patch`, and any patch-only PR. `npm-runtime`, security groups, and anything with a major in it still need manual review.

Notes on why it's written the way it is:

- Uses `--merge`, not `--squash`: squash merge is disabled on this repo (`allow_squash_merge: false`).
- Uses `on: pull_request`, not `pull_request_target`: Dependabot PRs already receive a write `GITHUB_TOKEN` here — verified by the CI-summary comment in `test.yml` posting successfully on #262.
- No approval step: `required_approving_review_count` is 0, so one isn't needed, and adding one would require the "Allow GitHub Actions to create and approve pull requests" setting.

Prerequisites are already satisfied: `allow_auto_merge: true`, and `🚦 Status Check` is the required check on `main`.

## After merging

Close the 8 open ungrouped security PRs (#251 is a duplicate of #258). Dependabot re-evaluates alerts within a day and reopens them as a single grouped PR. `@dependabot reopen` restores any of them if needed.
