### PR TITLE
ci: bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -29,7 +29,7 @@ jobs:
         run: yarn install
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
       - run: yarn install --immutable

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,12 +2,17 @@ name: Close stale issues and PRs
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v11
         with:
           stale-issue-message: This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.
           stale-pr-message: This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.
@@ -17,3 +22,6 @@ jobs:
           days-before-pr-stale: 45
           days-before-issue-close: 5
           days-before-pr-close: 10
+          # v6 changed the default close reason from `completed` to
+          # `not_planned`. Stated explicitly so the behaviour is visible.
+          close-issue-reason: not_planned

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn
@@ -40,16 +40,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           cache: pip
@@ -85,7 +85,7 @@ jobs:
         # continue-on-error: true  # don't use it, so a proper error will show. instead, we use if: always() on the rest of the steps
 
       - name: Upload test results to GitHub
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         if: always()
         with:
           name: UI Test Results
@@ -94,7 +94,7 @@ jobs:
           fail-on-error: false
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results
@@ -105,7 +105,7 @@ jobs:
             test-resources/*.json
 
       - name: Store UI test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure() || cancelled()
         with:
           name: logs-ubuntu-latest
@@ -114,7 +114,7 @@ jobs:
             test-resources/*.log
 
       - name: Store UI Test screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: screenshots-ubuntu-latest
@@ -157,17 +157,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 
       - name: Cache Python venv
         id: cache-venv
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .venv
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('tests/test-data/workspace/requirements.txt', 'tests/unit/python/requirements.txt') }}
@@ -186,7 +186,7 @@ jobs:
           .venv/bin/pytest tests/unit/python/ -v --junitxml=test-results/python-unit-junit.xml
 
       - name: Upload Python unit test results to GitHub
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         if: always()
         with:
           name: Python Unit Test Results
@@ -195,7 +195,7 @@ jobs:
           fail-on-error: false
 
       - name: Upload Python unit test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: python-unit-test-results
@@ -244,10 +244,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn
@@ -261,7 +261,7 @@ jobs:
           MOCHA_JUNIT=true yarn test:unit:ts
 
       - name: Upload TS unit test results to GitHub
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         if: always()
         with:
           name: TypeScript Unit Test Results
@@ -270,7 +270,7 @@ jobs:
           fail-on-error: false
 
       - name: Upload TS unit test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ts-unit-test-results
@@ -313,10 +313,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
@@ -331,7 +331,7 @@ jobs:
         run: yarn package
 
       - name: Upload VSIX
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: extension-vsix
           path: '*.vsix'
@@ -340,10 +340,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
@@ -401,7 +401,7 @@ jobs:
           exit 1
 
       - name: Post PR summary comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event_name == 'pull_request'
         with:
           script: |


### PR DESCRIPTION
Companion to #264. The workflows were between 2 and 7 majors behind, so the first grouped `github-actions` Dependabot PR would otherwise have been this entire jump at once. Doing it here instead, deliberately, with the release notes read.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v3, v4 | **v7** |
| `actions/setup-node` | v3, v4 | **v7** |
| `actions/setup-python` | v5 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/cache` | v4 | **v6** |
| `actions/github-script` | v7 | **v9** |
| `dorny/test-reporter` | v1 | **v3** |
| `actions/stale` | v4 | **v11** |

`HaaLeo/publish-vscode-extension` stays at `v2`, which is current.

## Breaking changes reviewed

I read the notes for every intervening major. None of them affect how these actions are used here:

- **`github-script@v9`** drops `require('@actions/github')` and injects `getOctokit` instead. The CI-summary script only uses the injected `github` / `context` and does no `require`, so it's unaffected.
- **`setup-node@v5`** added automatic caching driven by the `packageManager` field; **v6** narrowed that back to npm only. Every job that needs caching already passes `cache: yarn` explicitly, so behaviour is unchanged either way.
- **`actions/stale`**: all eight inputs used here are still present in v11's `action.yml`. v6 changed the default close reason from `completed` to `not_planned` — now stated explicitly in the file rather than changing silently.
- **v5+ of several actions** require runner ≥ 2.327.1, which GitHub-hosted `ubuntu-latest` satisfies.

## Also in here

`stale.yml` had no `permissions:` block at all, and `actions/stale` needs `issues: write` and `pull-requests: write`. Added, along with a `workflow_dispatch` trigger so it can be tested without waiting for the 01:30 cron.

## Not addressed here

Three pre-existing things I noticed but left alone:

- `copilot-setup-steps.yml` keys its cargo cache on `hashFiles('**/Cargo.lock')`, but no `Cargo.lock` is committed — `hashFiles` returns empty, so the key is a constant `Linux-cargo-` that never invalidates.
- In `test.yml`, the `build` and `security` jobs pin `node-version: 20` while `lint` / `test` / `ts-unit-test` use 22, and `.node-version` says v22.18.0.
- The `security` job's `yarn audit --level moderate` has `continue-on-error: true`, so it can never fail the build.
