### PR TITLE
ci(dependabot): make cargo genuinely patch-only, drop duplicate /icons PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,8 +108,39 @@ updates:
       cargo-security:
         applies-to: security-updates
         patterns: ['*']
+    ignore:
+      # `groups.update-types` above only controls how updates are *bundled*, not
+      # whether Dependabot opens a PR at all - anything outside a group still
+      # arrives as its own PR. Without this, `strum = "0.25"` -> "0.28" showed up
+      # individually (#266), which is exactly what patch-only was meant to avoid.
+      #
+      # Trade-off: `ignore` suppresses security updates too, so a Rust advisory
+      # that needs a minor bump will show as an alert in the Security tab with no
+      # PR attached. Deliberate - these crates are all 0.x, where a minor bump is
+      # a breaking change, and there is no Cargo.lock to pin what resolved.
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+
+  # ── icons workspace member ──────────────────────────────────────────────────
+  # `icons` is a yarn workspace member with no lockfile of its own, so a
+  # directory-scoped update edits icons/package.json and leaves the root
+  # yarn.lock untouched - which `yarn install --immutable` rejects outright
+  # (YN0028), as seen in #267. The root `/` entry above already updates these
+  # dependencies correctly through the workspace (svgo 2.8.3 arrived that way in
+  # #270), so this entry exists only to suppress the duplicate.
+  - package-ecosystem: npm
+    directory: /icons
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '*'
 
   # ── example-plugin ──────────────────────────────────────────────────────────
+  # Unlike `icons`, this one has its own yarn.lock, so directory-scoped updates
+  # here resolve cleanly.
   # Demo code with its own yarn.lock and no CI. No version updates (limit 0),
   # but keep security fixes flowing as a single grouped PR.
   - package-ecosystem: npm


### PR DESCRIPTION
Two gaps surfaced in the first batch of grouped PRs.

## 1. `groups.update-types` does not gate PR creation

It only controls how updates are **bundled**. Anything that doesn't match a group still arrives as its own PR, subject to `open-pull-requests-limit`. So despite the cargo group being `update-types: [patch]`, #266 turned up as `strum "0.25" -> "0.28"` — a 0.x minor, i.e. a breaking bump — and it moved `strum` while leaving `strum_macros = "0.25"` behind.

Fixed with an explicit `ignore` for semver-minor and semver-major on the cargo entry.

**Trade-off, documented in the file:** `ignore` suppresses security updates too, so a Rust advisory that needs a minor bump will show up as an alert in the Security tab with no PR attached. Accepted deliberately — every crate there is 0.x where a minor bump is breaking, and there's no `Cargo.lock` to pin what actually resolved. Worth revisiting if a Rust advisory ever lands.

## 2. `/icons` produced an unbuildable duplicate

`icons` is a yarn workspace member with **no lockfile of its own**. Dependabot scoped a security update to `/icons`, edited `icons/package.json` alone, and left the root `yarn.lock` untouched — which `yarn install --immutable` rejects outright:

```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

That's why #267 failed `lint` and `security` while every other PR in the batch was green.

The root `/` entry already handles these dependencies correctly through the workspace — svgo 2.8.3 came through that way in #270 and passed everything. So `/icons` is now declared purely to suppress the duplicate.

`example-plugin` is deliberately left as-is: it has its own `yarn.lock`, so directory-scoped updates there resolve cleanly (#268 merged green).

## Not changed

npm **majors** will still arrive as individual PRs (limit 3, after a 30-day cooldown). That's intentional — a major like `eslint 9 -> 10` wants to be looked at on its own rather than bundled with unrelated bumps. Say the word if you'd rather ignore them entirely.