### PR TITLE
ci(dependabot): auto-rebase open PRs after every merge to main

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -1,0 +1,32 @@
+# After anything merges into `main`, any other open Dependabot PR touching
+# the same lockfile (yarn.lock, Cargo.lock) is left behind and needs a manual
+# `@dependabot rebase` comment to catch up - Dependabot only auto-rebases when
+# it can do so without a conflict. This asks it to rebase every open
+# Dependabot PR so that never has to be done by hand.
+name: Rebase Dependabot PRs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: dependabot-rebase
+  cancel-in-progress: false
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ask Dependabot to rebase open PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh pr list --author "app/dependabot" --state open --json number \
+            --jq '.[].number' | while read -r pr; do
+              echo "Requesting rebase for #$pr"
+              gh pr comment "$pr" --body '@dependabot rebase'
+            done


### PR DESCRIPTION
## Why

Dependabot only auto-rebases a PR when it can do so without a conflict. This repo groups PRs that share `yarn.lock`/`Cargo.lock`, so merging one Dependabot PR regularly leaves other open Dependabot PRs conflicting - previously requiring a manual `@dependabot rebase` comment on each.

## What

Adds `.github/workflows/dependabot-rebase.yml`: on every push to `main`, it lists open Dependabot PRs and posts `@dependabot rebase` on each, so they catch up automatically instead of by hand.

Uses the default `GITHUB_TOKEN` with `pull-requests: write` only - no new secrets, consistent with `dependabot-auto-merge.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vhitn6LqPyAxm3JodBEg5Z