### PR TITLE
ci(dependabot): use a PAT to post @dependabot rebase comments

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -3,6 +3,14 @@
 # `@dependabot rebase` comment to catch up - Dependabot only auto-rebases when
 # it can do so without a conflict. This asks it to rebase every open
 # Dependabot PR so that never has to be done by hand.
+#
+# Dependabot rejects command comments ("Sorry, only users with push access
+# can use that command") posted as github-actions[bot] via the default
+# GITHUB_TOKEN - the command check looks at the actual commenting identity,
+# and the workflow token's bot identity doesn't count, even though it has
+# write access to post the comment. A PAT from a real collaborator with push
+# access is required instead. `DEPENDABOT_REBASE_TOKEN` is a fine-grained PAT
+# scoped to this repo only, with "Pull requests: Read and write" permission.
 name: Rebase Dependabot PRs
 
 on:
@@ -10,7 +18,7 @@ on:
     branches: [main]
 
 permissions:
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: dependabot-rebase
@@ -22,7 +30,7 @@ jobs:
     steps:
       - name: Ask Dependabot to rebase open PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_REBASE_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           gh pr list --author "app/dependabot" --state open --json number \


### PR DESCRIPTION
## Why

Follow-up to #278. That workflow ran successfully and posted `@dependabot rebase` on the open Dependabot PRs, but Dependabot rejected every one of them:

> Sorry, only users with push access can use that command.

Dependabot's command check looks at the actual commenting identity. `github-actions[bot]` (the default `GITHUB_TOKEN`) doesn't satisfy it, even though the token has write access to post the comment itself - confirmed on #275, #276, #277.

## What

Switch the comment step to `DEPENDABOT_REBASE_TOKEN`, a fine-grained PAT scoped to this repo only (`Pull requests: Read and write`) from a collaborator with real push access. Also drops the now-unused `pull-requests: write` permission grant on `GITHUB_TOKEN` in favor of `contents: read`, since the PAT is what actually posts the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vhitn6LqPyAxm3JodBEg5Z